### PR TITLE
autosize.destory方法不存在，单词拼写错误，应该是destroy

### DIFF
--- a/src/TextareaFormField.js
+++ b/src/TextareaFormField.js
@@ -34,7 +34,7 @@ class TextAreaFormField extends FormField {
         if (!me.props.standalone) {
             this.props.detachFormField(this);
         }
-        me.props.autosize && autosize.destory(me.refs.root);
+        me.props.autosize && autosize.destroy(me.refs.root);
     }
 
     componentDidUpdate(prevProps, prevState) {
@@ -45,7 +45,7 @@ class TextAreaFormField extends FormField {
             autosize(me.refs.root);
         }
         else if (prevMode == Constants.MODE.EDIT && mode == Constants.MODE.MODE) {
-            autosize.destory(me.refs.root);
+            autosize.destroy(me.refs.root);
         }
     }
 


### PR DESCRIPTION
单词拼写错误了，demo中测试不到autosize.destroy(me.refs.root) 方法，所以发现不了；
项目中发现了，项目中使用的是uxcore-form@1.3.10版本，依赖uxcore-textarea-form-field版本0.1.1；
代码合并后，uxcore-form需要发布一个新版本；