### PR TITLE
fix autosize does not trigger when form.resetValues() calls

### DIFF
--- a/src/TextareaFormField.jsx
+++ b/src/TextareaFormField.jsx
@@ -70,12 +70,12 @@ class TextAreaFormField extends FormField {
     }
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
     const me = this;
     const mode = me.props.jsxmode || me.props.mode;
     const prevMode = prevProps.jsxmode || prevProps.mode;
     if (me.props.autosize) {
-      if (prevProps.value !== me.props.value) {
+      if (prevProps.value !== me.props.value || prevState.value !== me.state.value) {
         autosize.update(me.root);
       }
       if (prevMode === Constants.MODE.VIEW && mode === Constants.MODE.EDIT) {


### PR DESCRIPTION
prevProps.value is equal to me.props.value when form.resetValues() calls